### PR TITLE
Maps Call

### DIFF
--- a/calls/v1/maps/TripalWebServiceBrapiV1Maps.inc
+++ b/calls/v1/maps/TripalWebServiceBrapiV1Maps.inc
@@ -183,6 +183,7 @@ class TripalWebServiceBrapiV1Maps extends TripalWebServiceDatabaseCall {
       foreach($result as $map) {
         // Comments.
         $map->comments = trim(html_entity_decode(strip_tags($map->comments)));
+        $map->markercount = (int) $map->markercount;
 
         array_push($maps, $map);
       }

--- a/tests/calls-v.13/mapsCallTest.php
+++ b/tests/calls-v.13/mapsCallTest.php
@@ -1,0 +1,67 @@
+<?php
+namespace Tests\calls;
+
+use StatonLab\TripalTestSuite\TripalTestCase;
+use Tests\GenericHttpTestCase;
+
+/**
+ * Maps Call (Version 1.3)
+ * https://brapi.docs.apiary.io/#reference/genome-maps/maps/get-maps
+ */
+class mapsCallTest extends GenericHttpTestCase {
+
+  /**
+   * The short name of the call for Assestion messages.
+   */
+  public $callname = 'maps';
+
+  /**
+   * The URL for the call for requests.
+   * For example: web-services/brapi/v1/people
+   */
+  public $url = 'web-services/brapi/v1/maps';
+
+  /**
+   * The structure of the data result.
+   * Each entry should be key => valuetype | array.
+   * Valid valuetypes are: string, integer, object, array.
+   */
+  public $data_structure = [
+    'comments' => 'string',
+    'commonCropName' => 'string',
+    'documentationURL' => 'string', // uri
+    'linkageGroupCount' => 'string',
+    'mapDbId' => 'string',
+    'mapName' => 'string',
+    'markerCount' => 'integer',
+    'name' => 'string', // Deprecated in 1.3
+    'publishedDate' => 'string', // date
+    'species' => 'string', // Deprecated in 1.3.
+    'scientificName' => 'string',
+    'type' => 'string',
+    'unit' => 'string',
+  ];
+
+  /**
+   * CORE TEST.
+   */
+  public function testCall() {
+
+    //---------------------------------
+    // 1. NO PARAMETERS.
+    $response = NULL;
+    $this->assertWithNoParameters($response);
+    // $numOfResults = sizeof($response->result->data);
+
+    //---------------------------------
+    // 2. WITH PARAMETERS: pageSize
+    // $response = NULL;
+    // $this->assertPageSize($response, $numOfResults);
+    // $page1_results = $response->result->data;
+
+    //---------------------------------
+    // 3. WITH PARAMETERS: page, pageSize
+    // $response = NULL;
+    // $this->assertPaging($response, $numOfResults, $page1_results);
+  }
+}

--- a/tests/calls-v.13/mapsCallTest.php
+++ b/tests/calls-v.13/mapsCallTest.php
@@ -51,17 +51,40 @@ class mapsCallTest extends GenericHttpTestCase {
     // 1. NO PARAMETERS.
     $response = NULL;
     $this->assertWithNoParameters($response);
-    // $numOfResults = sizeof($response->result->data);
+    $numOfResults = sizeof($response->result->data);
 
     //---------------------------------
     // 2. WITH PARAMETERS: pageSize
-    // $response = NULL;
-    // $this->assertPageSize($response, $numOfResults);
-    // $page1_results = $response->result->data;
+    $response = NULL;
+    $this->assertPageSize($response, $numOfResults);
+    $page1_results = $response->result->data;
 
     //---------------------------------
     // 3. WITH PARAMETERS: page, pageSize
-    // $response = NULL;
-    // $this->assertPaging($response, $numOfResults, $page1_results);
+    $response = NULL;
+    $this->assertPaging($response, $numOfResults, $page1_results);
+
+    //---------------------------------
+    // 3. WITH PARAMETERS: species, commonCropName, type
+    $response = NULL;
+    $this->assertWithParameter($response, [
+      'name' => 'species', // Parameter name.
+      'key'   => 'species', // The response key the parameter name will match.
+      'value'  => 'ferox' // Parameter value.
+    ]);
+
+    $response = NULL;
+    $this->assertWithParameter($response, [
+      'name' => 'commonCropName', // Parameter name.
+      'key'   => 'commonCropName', // The response key the parameter name will match.
+      'value'  => 'Tripalus' // Parameter value.
+    ]);
+
+    $response = NULL;
+    $this->assertWithParameter($response, [
+      'name' => 'type', // Parameter name.
+      'key'   => 'type', // The response key the parameter name will match.
+      'value'  => 'genetic' // Parameter value.
+    ]);
   }
 }

--- a/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featuremap-csv.csv
+++ b/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featuremap-csv.csv
@@ -1,3 +1,5 @@
 name, description, translate_term:unittype_id
 "MAP 1 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", "Nulla quis velit maximus leo maximus hendrerit non sit amet justo. Donec imperdiet ex eget libero gravida sagittis. Pellentesque malesuada porta lacus, porta molestie nulla interdum a. Fusce at orci et nisi pretium venenatis at non neque", cM
 "MAP 2 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", "Suspendisse commodo tincidunt felis, in sodales quam convallis aliquet. Nullam at convallis ligula. Morbi sit amet metus et nisl aliquam gravida", cM
+"MAP 3 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", "Donec imperdiet ex eget libero gravida sagittis. Pellentesque malesuada porta lacus, porta molestie nulla interdum a. Fusce at orci et nisi pretium venenatis at non neque", cM
+"MAP 4 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", "Nullam at convallis ligula. Morbi sit amet metus et nisl aliquam gravida", cM

--- a/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featuremap_organism-csv.csv
+++ b/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featuremap_organism-csv.csv
@@ -1,3 +1,5 @@
 translate_value:featuremap_id, translate_value:organism_id
 "MAP 1 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", "Wild Tripal"
 "MAP 2 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", "Tripal WS"
+"MAP 3 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", "Wild Tripal"
+"MAP 4 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", "Tripal WS"

--- a/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featuremapprop-csv.csv
+++ b/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featuremapprop-csv.csv
@@ -1,3 +1,5 @@
 translate_value:name, MAIN:map_type
 "MAP 1 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", genetic
 "MAP 2 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", genetic
+"MAP 3 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", genetic
+"MAP 4 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", genetic

--- a/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featurepos-csv.csv
+++ b/tripal_ws_brapi_testdata/includes/raw-data/featuremap/featurepos-csv.csv
@@ -103,3 +103,5 @@ translate_value:featuremap_id, translate_value:feature_id, translate_value:map_f
 "MAP 2 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", LcCX2 Assay, lgA2, 1.0
 "MAP 2 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", LcCY2 Assay, lgA2, 1.0
 "MAP 2 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", LcCZ2 Assay, lgA2, 1.0
+"MAP 3 (Germ1 X Germ2 RIL); Person 1; Plant Genome 2013", LcCY2 Assay, lgA2, 1.0
+"MAP 4 (Germ1 X Germ2 RIL); Person 1; BMC Genomic 2013", LcCZ2 Assay, lgA2, 1.0


### PR DESCRIPTION
Tests `web-services/brapi/v1/maps` for BrAPI 1.3
https://brapi.docs.apiary.io/#reference/genome-maps/maps/get-maps

This PR adds a test for the maps call. The test currently fails due to non-compliance of this call. Specifically,

```
1) Tests\calls\mapsCallTest::testCall
The value of markerCount should be a integer.
Failed asserting that '26' is of type "int".
```

@reynoldtan can you please fix the call on the `call-maps` branch so this call matches the specification.