### PR TITLE
Fixes bug in pageSize of custom calls

### DIFF
--- a/class/TripalWebServiceCall.inc
+++ b/class/TripalWebServiceCall.inc
@@ -681,7 +681,7 @@ class TripalWebServiceCall {
       $resultset_limit = $this->getResultsetLimit();
       $current_page = (isset($parameter['page'])) ? $parameter['page'] : 0;
 
-      $start_at = $current_page * $resultset_limit;
+      $start_at = 0;
       $stop_at  = $start_at + $resultset_limit - 1;
 
       $response_subset_ctr = 0;


### PR DESCRIPTION
This fixes a bug in determining pageSize in custom calls caused by the original design of custom calls not supporting pageSize and/or dataType parameters.